### PR TITLE
One shall not use PHP variables of any kind inside a translation functio...

### DIFF
--- a/classes/post_type.class.php
+++ b/classes/post_type.class.php
@@ -73,8 +73,8 @@ class Cuztom_Post_Type
 				'all_items' 			=> __( 'All ' . $plural, CUZTOM_TEXTDOMAIN ),
 				'view_item' 			=> __( 'View ' . $name, CUZTOM_TEXTDOMAIN ),
 				'search_items' 			=> __( 'Search ' . $plural, CUZTOM_TEXTDOMAIN ),
-				'not_found' 			=> __( 'No ' . strtolower( $plural ) . ' found', CUZTOM_TEXTDOMAIN ),
-				'not_found_in_trash' 	=> __( 'No ' . strtolower( $plural ) . ' found in Trash', CUZTOM_TEXTDOMAIN ), 
+				'not_found' 			=> sprintf( __( 'No %s found', CUZTOM_TEXTDOMAIN ), strtolower( $plural ) ),
+				'not_found_in_trash' 	=> sprintf( __( 'No %s found in trash', CUZTOM_TEXTDOMAIN ), strtolower( $plural ) ),
 				'parent_item_colon' 	=> '',
 				'menu_name' 			=> $plural
 			),


### PR DESCRIPTION
One shall not use PHP variables of any kind inside a translation function's string because translation relies on looking up strings in a table and then translating them. That is done by code which scans your PHP code (NOT executing it) and pulls out all the __()’s it finds, then builds the list of strings to be translated. That scanning code cannot possibly know what is inside $string. And ideally, phrases should be translated, not words. 
