### PR TITLE
On PHP < 5.3 you can't do dynamic loading with static class functions, y...

### DIFF
--- a/functions/field.php
+++ b/functions/field.php
@@ -7,10 +7,10 @@ function cuztom_field( $value )
 
 function _cuztom_field_supports_repeatable( $field )
 {
-	return call_user_func( array($field, '_supports_repeatable') );
+	return $field->_supports_repeatable();
 }
 
 function _cuztom_field_supports_bundle( $field )
 {
-	return call_user_func( array($field, '_supports_bundle') );
+	return $field->_supports_bundle();
 }


### PR DESCRIPTION
...ou get "Parse error: syntax error, unexpected T_PAAMAYIM_NEKUDOTAYIM in /Wordpress-Cuztom-Helper/functions/field.php" on line 10 and 15
