### PR TITLE
Added a note to flush rewrite rules on activation in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,9 @@ Include the main file.
 	
 	$book = register_cuztom_post_type( 'Book' );
 	
+
+**Note:** If you're using Custom Post Types, don't forget to *[flush rewrite rules on activation](http://codex.wordpress.org/Function_Reference/register_post_type#Flushing_Rewrite_on_Activation "Flushing Rewrite Rules on Activation")*.
+
 ### Add Custom Taxonomies
 	
 To add Custom Taxonomies to the newly created Post Type, simply call this method.


### PR DESCRIPTION
To get permalinks to work properly, rewrite rules should be flushed on theme or plugin activation after custom post types are registered. Reference: http://codex.wordpress.org/Function_Reference/register_post_type#Flushing_Rewrite_on_Activation
