### PR TITLE
Update term_checkboxes.class.php

### DIFF
--- a/classes/fields/term_checkboxes.class.php
+++ b/classes/fields/term_checkboxes.class.php
@@ -12,7 +12,7 @@ class Cuztom_Field_Term_Checkboxes extends Cuztom_Field
 
 		$this->args = array_merge(
 			array(
-				'taxonomy'		=> 'category',
+				'taxonomy'		=> $this->options['taxonomy'],
 			),
 			$this->args
 		);


### PR DESCRIPTION
The term_checkboxes option is not getting custom taxonomy and showing "post category" even when we set it.
