### PR TITLE
move check post type to init

### DIFF
--- a/classes/post_type.class.php
+++ b/classes/post_type.class.php
@@ -52,11 +52,7 @@ class Cuztom_Post_Type
 			$this->labels 		= $labels;
 			$this->add_features	= $this->remove_features = array();
 
-			// Add action to register the post type, if the post type doesnt exist
-			if( ! post_type_exists( $this->name ) )
-			{
-				$this->register_post_type();
-			}
+			$this->register_post_type();
 		}
 	}
 	
@@ -102,8 +98,12 @@ class Cuztom_Post_Type
 			$this->args
 		);
 
-		// Register the post type
-		register_post_type( $this->name, $args );
+		//  check the post type on init, and register only if the post type doesnt exist
+		if( ! post_type_exists( $this->name ) )
+		{
+			register_post_type( $this->name, $args );
+		}
+		
 	}
 	
 	/**

--- a/classes/post_type.class.php
+++ b/classes/post_type.class.php
@@ -52,7 +52,7 @@ class Cuztom_Post_Type
 			$this->labels 		= $labels;
 			$this->add_features	= $this->remove_features = array();
 
-			$this->register_post_type();
+			add_action( 'init', array( $this, 'register_post_type' ) );
 		}
 	}
 	


### PR DESCRIPTION
need to check `post_type_exists()` on `init` for user that use this awesome helper on **mu plugins** folder, otherwise the `post_type_exists` will always return `true` even if post type has been registered, or they will got error `Fatal error: Call to a member function add_rewrite_tag() on a non-object in /.../wp-includes/rewrite.php on line 54`