### PR TITLE
Some fixes to use cuztom in forigners languages

### DIFF
--- a/classes/post_type.class.php
+++ b/classes/post_type.class.php
@@ -37,13 +37,21 @@ class Cuztom_Post_Type
 			// If $name is an array, the first element is the singular name, the second is the plural name
 			if( is_array( $name ) )
 			{
-				$this->name		= Cuztom::uglify( $name[0] );
-				$this->title	= Cuztom::beautify( $name[0] );
-				$this->plural 	= Cuztom::beautify( $name[1] );
+				if(count($name) > 2)
+				{
+					$this->name	= Cuztom::uglify( $name[0] );
+					$this->title	= Cuztom::beautify( $name[1] );
+					$this->plural 	= Cuztom::beautify( $name[2] );
+				}
+				else {
+					$this->name	= Cuztom::uglify( $name[0] );
+					$this->title	= Cuztom::beautify( $name[0] );
+					$this->plural 	= Cuztom::beautify( $name[1] );
+				}
 			}
 			else
 			{
-				$this->name		= Cuztom::uglify( $name );
+				$this->name	= Cuztom::uglify( $name );
 				$this->title	= Cuztom::beautify( $name );
 				$this->plural 	= Cuztom::pluralize( Cuztom::beautify( $name ) );
 			}

--- a/classes/taxonomy.class.php
+++ b/classes/taxonomy.class.php
@@ -39,13 +39,21 @@ class Cuztom_Taxonomy
 
 			if( is_array( $name ) )
 			{
-				$this->name		= Cuztom::uglify( $name[0] );
-				$this->title	= Cuztom::beautify( $name[0] );
-				$this->plural 	= Cuztom::beautify( $name[1] );
+				if(count($name) > 2)
+				{
+					$this->name	= Cuztom::uglify( $name[0] );
+					$this->title	= Cuztom::beautify( $name[1] );
+					$this->plural 	= Cuztom::beautify( $name[2] );
+				}
+				else {
+					$this->name	= Cuztom::uglify( $name[0] );
+					$this->title	= Cuztom::beautify( $name[0] );
+					$this->plural 	= Cuztom::beautify( $name[1] );
+				}
 			}
 			else
 			{
-				$this->name		= Cuztom::uglify( $name );
+				$this->name	= Cuztom::uglify( $name );
 				$this->title	= Cuztom::beautify( $name );
 				$this->plural 	= Cuztom::pluralize( Cuztom::beautify( $name ) );
 			}

--- a/classes/taxonomy.class.php
+++ b/classes/taxonomy.class.php
@@ -232,7 +232,7 @@ class Cuztom_Taxonomy
 		if( in_array( $typenow, $this->post_type ) )
 		{
 			wp_dropdown_categories( array(
-				'show_option_all'	=> sprintf( __( 'Show all %s', 'cuztom' ), $this->plural ),
+				'show_option_all'	=> $this->labels['all_items'],
 				'taxonomy'       	=> $this->name,
 				'name'            	=> $this->name,
 				'orderby'         	=> 'name',


### PR DESCRIPTION
With these three little changes is more easy to translate the labels without changes the name of taxonomies and post_types and they allow to show customized all_items label in backend filter.
Hope they're useful.

Lapo