### PR TITLE
Move Cuztom::run to cuztom.php

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,58 @@
+<?php
+
+// Cuztom
+require_once __DIR__.'/src/Cuztom.php';
+
+// Support
+require_once __DIR__.'/Support/Guard.php';
+require_once __DIR__.'/Support/Notice.php';
+require_once __DIR__.'/Support/Ajax.php';
+require_once __DIR__.'/Support/Request.php';
+require_once __DIR__.'/Support/Response.php';
+
+// Entity
+require_once __DIR__.'/Entities/Entity.php';
+require_once __DIR__.'/Entities/PostType.php';
+require_once __DIR__.'/Entities/Taxonomy.php';
+require_once __DIR__.'/Entities/Sidebar.php';
+require_once __DIR__.'/Entities/helpers.php';
+
+// Meta
+require_once __DIR__.'/Meta/Meta.php';
+require_once __DIR__.'/Meta/Box.php';
+require_once __DIR__.'/Meta/User.php';
+require_once __DIR__.'/Meta/Term.php';
+require_once __DIR__.'/Meta/helpers.php';
+
+// Fields
+require_once __DIR__.'/Fields/Traits/Checkable.php';
+require_once __DIR__.'/Fields/Traits/Checkables.php';
+require_once __DIR__.'/Fields/Traits/Selectable.php';
+require_once __DIR__.'/Fields/Field.php';
+require_once __DIR__.'/Fields/Bundle.php';
+require_once __DIR__.'/Fields/Bundle/Item.php';
+require_once __DIR__.'/Fields/Tabs.php';
+require_once __DIR__.'/Fields/Accordion.php';
+require_once __DIR__.'/Fields/Tab.php';
+require_once __DIR__.'/Fields/Text.php';
+require_once __DIR__.'/Fields/Textarea.php';
+require_once __DIR__.'/Fields/Checkbox.php';
+require_once __DIR__.'/Fields/YesNo.php';
+require_once __DIR__.'/Fields/Select.php';
+require_once __DIR__.'/Fields/MultiSelect.php';
+require_once __DIR__.'/Fields/Checkboxes.php';
+require_once __DIR__.'/Fields/Radios.php';
+require_once __DIR__.'/Fields/Wysiwyg.php';
+require_once __DIR__.'/Fields/Image.php';
+require_once __DIR__.'/Fields/File.php';
+require_once __DIR__.'/Fields/DateTime.php';
+require_once __DIR__.'/Fields/Date.php';
+require_once __DIR__.'/Fields/Time.php';
+require_once __DIR__.'/Fields/Color.php';
+require_once __DIR__.'/Fields/PostSelect.php';
+require_once __DIR__.'/Fields/PostCheckboxes.php';
+require_once __DIR__.'/Fields/TermSelect.php';
+require_once __DIR__.'/Fields/TermCheckboxes.php';
+require_once __DIR__.'/Fields/TaxonomySelect.php';
+require_once __DIR__.'/Fields/TaxonomyCheckboxes.php';
+require_once __DIR__.'/Fields/Hidden.php';

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,10 @@
     "autoload": {
         "psr-4": {
             "Gizburdt\\Cuztom\\": "src/"
-        }
+        },
+        "files": [
+            "src/Entities/helpers.php",
+            "src/Meta/Helpers.php"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         },
         "files": [
             "src/Entities/helpers.php",
-            "src/Meta/Helpers.php"
+            "src/Meta/helpers.php"
         ]
     }
 }

--- a/cuztom.php
+++ b/cuztom.php
@@ -2,3 +2,5 @@
 
 // Include Cuztom
 require_once dirname(__FILE__).'/src/Cuztom.php';
+
+Cuztom::run();

--- a/cuztom.php
+++ b/cuztom.php
@@ -1,8 +1,10 @@
 <?php
 
-// Include Cuztom
-require_once dirname(__FILE__).'/src/Cuztom.php';
+// Bootstrap
+require_once __DIR__.'/bootstrap.php';
 
+// Import Cuztom
 use Gizburdt\Cuztom\Cuztom;
 
+// Run the plugin
 Cuztom::run();

--- a/cuztom.php
+++ b/cuztom.php
@@ -1,10 +1,9 @@
 <?php
 
+use Gizburdt\Cuztom\Cuztom;
+
 // Bootstrap
 require_once __DIR__.'/bootstrap.php';
-
-// Import Cuztom
-use Gizburdt\Cuztom\Cuztom;
 
 // Run the plugin
 Cuztom::run();

--- a/cuztom.php
+++ b/cuztom.php
@@ -3,4 +3,6 @@
 // Include Cuztom
 require_once dirname(__FILE__).'/src/Cuztom.php';
 
+use Gizburdt\Cuztom\Cuztom;
+
 Cuztom::run();

--- a/src/Cuztom.php
+++ b/src/Cuztom.php
@@ -606,5 +606,3 @@ class Cuztom
         return new \WP_Error('cuztom_reserved_term_used', __('Use of a reserved term.', 'cuztom'));
     }
 }
-
-Cuztom::run();

--- a/src/Cuztom.php
+++ b/src/Cuztom.php
@@ -79,7 +79,6 @@ class Cuztom
             self::$instance = new self();
 
             self::$instance->setup();
-            self::$instance->includes();
             self::$instance->execute();
             self::$instance->hooks();
             self::$instance->ajax();
@@ -100,15 +99,6 @@ class Cuztom
 
         // Do
         do_action('cuztom_setup');
-    }
-
-    /**
-     * Include the necessary files.
-     */
-    private function includes()
-    {
-        // Do
-        do_action('cuztom_includes');
     }
 
     /**

--- a/src/Cuztom.php
+++ b/src/Cuztom.php
@@ -107,60 +107,6 @@ class Cuztom
      */
     private function includes()
     {
-        // Support
-        require_once self::$src.'/Support/Guard.php';
-        require_once self::$src.'/Support/Notice.php';
-        require_once self::$src.'/Support/Ajax.php';
-        require_once self::$src.'/Support/Request.php';
-        require_once self::$src.'/Support/Response.php';
-
-        // Entity
-        require_once self::$src.'/Entities/Entity.php';
-        require_once self::$src.'/Entities/PostType.php';
-        require_once self::$src.'/Entities/Taxonomy.php';
-        require_once self::$src.'/Entities/Sidebar.php';
-        require_once self::$src.'/Entities/helpers.php';
-
-        // Meta
-        require_once self::$src.'/Meta/Meta.php';
-        require_once self::$src.'/Meta/Box.php';
-        require_once self::$src.'/Meta/User.php';
-        require_once self::$src.'/Meta/Term.php';
-        require_once self::$src.'/Meta/helpers.php';
-
-        // Fields
-        require_once self::$src.'/Fields/Traits/Checkable.php';
-        require_once self::$src.'/Fields/Traits/Checkables.php';
-        require_once self::$src.'/Fields/Traits/Selectable.php';
-        require_once self::$src.'/Fields/Field.php';
-        require_once self::$src.'/Fields/Bundle.php';
-        require_once self::$src.'/Fields/Bundle/Item.php';
-        require_once self::$src.'/Fields/Tabs.php';
-        require_once self::$src.'/Fields/Accordion.php';
-        require_once self::$src.'/Fields/Tab.php';
-        require_once self::$src.'/Fields/Text.php';
-        require_once self::$src.'/Fields/Textarea.php';
-        require_once self::$src.'/Fields/Checkbox.php';
-        require_once self::$src.'/Fields/YesNo.php';
-        require_once self::$src.'/Fields/Select.php';
-        require_once self::$src.'/Fields/MultiSelect.php';
-        require_once self::$src.'/Fields/Checkboxes.php';
-        require_once self::$src.'/Fields/Radios.php';
-        require_once self::$src.'/Fields/Wysiwyg.php';
-        require_once self::$src.'/Fields/Image.php';
-        require_once self::$src.'/Fields/File.php';
-        require_once self::$src.'/Fields/DateTime.php';
-        require_once self::$src.'/Fields/Date.php';
-        require_once self::$src.'/Fields/Time.php';
-        require_once self::$src.'/Fields/Color.php';
-        require_once self::$src.'/Fields/PostSelect.php';
-        require_once self::$src.'/Fields/PostCheckboxes.php';
-        require_once self::$src.'/Fields/TermSelect.php';
-        require_once self::$src.'/Fields/TermCheckboxes.php';
-        require_once self::$src.'/Fields/TaxonomySelect.php';
-        require_once self::$src.'/Fields/TaxonomyCheckboxes.php';
-        require_once self::$src.'/Fields/Hidden.php';
-
         // Do
         do_action('cuztom_includes');
     }


### PR DESCRIPTION
This PR moves `Cuztom::run()` from the class file `src/Cuztom.php` to the root file `cuztom.php`. This will make usage with Composer easier, since just including `vendor/autoload.php` will not actually include `src/Cuztom.php` until you use the class somewhere.